### PR TITLE
Update package.json - added missing csv.fontFamily config definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
           "type": "string",
           "default": ",",
           "description": "CSV separator to use."
+        },
+         "csv.fontFamily": {
+          "type": "string",
+          "default": "Menlo",
+          "description": "CSV Font Family to use."
         }
       }
     },


### PR DESCRIPTION
What it says on the tin. VSCode doesn't recognize csv.fontFamily

![image](https://github.com/user-attachments/assets/fb881743-fbee-4aa7-aa10-67e2854b98ea)
