### PR TITLE
Fix docs Run Test button emphasis

### DIFF
--- a/vsc-extension-quickstart.md
+++ b/vsc-extension-quickstart.md
@@ -28,7 +28,7 @@
 
 * Install the [Extension Test Runner](https://marketplace.visualstudio.com/items?itemName=ms-vscode.extension-test-runner)
 * Run the "watch" task via the **Tasks: Run Task** command. Make sure this is running, or tests might not be discovered.
-* Open the Testing view from the activity bar and click the Run Test" button, or use the hotkey `Ctrl/Cmd + ; A`
+* Open the Testing view from the activity bar and click the **Run Test** button, or use the hotkey `Ctrl/Cmd + ; A`
 * See the output of the test result in the Test Results view.
 * Make changes to `src/test/extension.test.ts` or create new test files inside the `test` folder.
   * The provided test runner will only consider files matching the name pattern `**.test.ts`.


### PR DESCRIPTION
## Summary
- fix the wording for clicking the **Run Test** button in the quickstart guide

## Testing
- `npm run compile` *(fails: Cannot find module 'papaparse' etc.)*