### PR TITLE
Add activation and command tests

### DIFF
--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,15 +1,34 @@
 import * as assert from 'assert';
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import { CsvEditorProvider } from '../extension';
 
-suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+suite('CSV Extension', () => {
+  test('activates the extension', async () => {
+    const ext = vscode.extensions.getExtension('ReprEng.csv');
+    assert.ok(ext, 'Extension not found');
+    await ext!.activate();
+    assert.strictEqual(ext!.isActive, true);
+  });
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+  test('toggleHeader command flips configuration', async () => {
+    const config = vscode.workspace.getConfiguration('csv');
+    const original = config.get<boolean>('treatFirstRowAsHeader');
+    await vscode.commands.executeCommand('csv.toggleHeader');
+    const toggled = config.get<boolean>('treatFirstRowAsHeader');
+    assert.strictEqual(toggled, !original);
+    // revert to original
+    await vscode.commands.executeCommand('csv.toggleHeader');
+    const reverted = config.get<boolean>('treatFirstRowAsHeader');
+    assert.strictEqual(reverted, original);
+  });
+
+  test('opens CSV file using custom editor', async () => {
+    const doc = await vscode.workspace.openTextDocument({ language: 'csv', content: 'a,b\n1,2' });
+    await vscode.commands.executeCommand('vscode.openWith', doc.uri, 'csv.editor');
+    await new Promise(resolve => setTimeout(resolve, 500));
+    assert.ok(CsvEditorProvider.editors.length > 0, 'Custom editor did not open');
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    await new Promise(resolve => setTimeout(resolve, 100));
+    assert.strictEqual(CsvEditorProvider.editors.length, 0);
+  });
 });


### PR DESCRIPTION
## Summary
- replace sample tests with new extension activation tests
- add command toggle and webview open tests

## Testing
- `npm run compile` *(fails: Cannot find module 'papaparse', '@types/vscode', etc.)*