### PR TITLE
Fix in-cell mouse clicks canceling edit mode

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -599,7 +599,9 @@ class CsvEditorProvider implements vscode.CustomTextEditorProvider {
     </div>
     <div id="contextMenu"></div>
     <script nonce="${nonce}">
-      document.body.setAttribute('tabindex', '0'); document.body.focus();
+      document.body.setAttribute('tabindex', '0');
+      let editingCell = null, originalCellValue = "";
+      document.body.focus();
       window.addEventListener('mousedown', e => {
         if(!editingCell || !editingCell.contains(e.target as Node)){
           document.body.focus();
@@ -609,7 +611,6 @@ class CsvEditorProvider implements vscode.CustomTextEditorProvider {
       let lastContextIsHeader = false;   // remembers whether we right-clicked a <th>
       let isUpdating = false, isSelecting = false, anchorCell = null, currentSelection = [];
       let startCell = null, endCell = null, selectionMode = "cell";
-      let editingCell = null, originalCellValue = "";
       const table = document.querySelector('table');
       /* ──────────── VIRTUAL-SCROLL LOADER ──────────── */
       const CHUNK_SIZE = 1000;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -600,7 +600,11 @@ class CsvEditorProvider implements vscode.CustomTextEditorProvider {
     <div id="contextMenu"></div>
     <script nonce="${nonce}">
       document.body.setAttribute('tabindex', '0'); document.body.focus();
-      window.addEventListener('mousedown', () => document.body.focus());
+      window.addEventListener('mousedown', e => {
+        if(!editingCell || !editingCell.contains(e.target as Node)){
+          document.body.focus();
+        }
+      });
       const vscode = acquireVsCodeApi();
       let lastContextIsHeader = false;   // remembers whether we right-clicked a <th>
       let isUpdating = false, isSelecting = false, anchorCell = null, currentSelection = [];


### PR DESCRIPTION
## Summary
- keep focus on active cell when clicking inside an editable cell

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688135c3e054832dae741f3e321a3ec0