### PR TITLE
Stack overflow error when opening large CSV files ("Maximum call stack size exceeded")

### DIFF
--- a/src/CsvEditorProvider.ts
+++ b/src/CsvEditorProvider.ts
@@ -743,11 +743,7 @@ class CsvEditorController {
       return true; // with only one row visible, lean toward header
     }
 
-    const numColumns = Math.max(
-      headerRow.length,
-      ...body.map(r => r.length),
-      0
-    );
+    const numColumns = body.reduce((max, r) => Math.max(max, r.length), Math.max(headerRow.length, 0));
     const bodyColData = Array.from({ length: numColumns }, (_, i) => body.map(r => r[i] || ''));
     const bodyTypes = bodyColData.map(col => this.estimateColumnDataType(col));
     const headerTypes = Array.from({ length: numColumns }, (_, i) => this.estimateColumnDataType([headerRow[i] || '']));


### PR DESCRIPTION
### Description
Opening CSV files with many rows causes the extension to crash with `RangeError: Maximum call stack size exceeded.`

### Stack trace:
```
RangeError: Maximum call stack size exceeded
    at CsvEditorController.getEffectiveHeader (CsvEditorProvider.js:691:33)
    at CsvEditorController.updateWebviewContent (CsvEditorProvider.js:528:34)
    at CsvEditorController.resolveCustomTextEditor (CsvEditorProvider.js:66:14)
    ...
```

### Steps to reproduce
1. Open a file with a very large number of rows (see [energy_train.csv](https://github.com/user-attachments/files/24433125/energy_train.csv))
2. Observe the error



### Root Cause
The extension uses `Math.max(...array)` spread syntax in multiple locations to calculate the maximum column count. 
When the CSV has many rows, spreading the array into `Math.max()` exceeds JavaScript's call stack limit (~65K arguments).

### Fix suggestion
Use a stack-safe approach through using `reduce()`