### PR TITLE
Fix multiline edit loss when saving from editor (#75)

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -1760,8 +1760,12 @@ document.addEventListener('keydown', e => {
 
   if (editingCell && ((e.ctrlKey || e.metaKey) && e.key === 's')) {
     e.preventDefault();
-    editingCell.blur();
-    vscode.postMessage({ type: 'save' });
+    const cellRef = editingCell;
+    cellRef && cellRef.blur();
+    // Let blur's edit commit message flush first, then save.
+    setTimeout(() => {
+      vscode.postMessage({ type: 'save' });
+    }, 0);
   }
   if (editingCell && e.key === 'Enter') {
     e.preventDefault();

--- a/src/test/webview-edit-shortcuts.test.ts
+++ b/src/test/webview-edit-shortcuts.test.ts
@@ -48,6 +48,14 @@ describe('Webview edit shortcuts', () => {
     assert.ok(webviewSource.includes('setSingleSelection(nextCell);'));
   });
 
+  it('commits blur before save when using Ctrl/Cmd+S during edit', () => {
+    assert.ok(webviewSource.includes("if (editingCell && ((e.ctrlKey || e.metaKey) && e.key === 's')) {"));
+    assert.ok(webviewSource.includes("const cellRef = editingCell;"));
+    assert.ok(webviewSource.includes("cellRef && cellRef.blur();"));
+    assert.ok(webviewSource.includes("setTimeout(() => {"));
+    assert.ok(webviewSource.includes("vscode.postMessage({ type: 'save' });"));
+  });
+
   it('handles selection-mode paste as a grid operation', () => {
     assert.ok(webviewSource.includes("document.addEventListener('paste', e => {"));
     assert.ok(webviewSource.includes("type: 'pasteCells'"));


### PR DESCRIPTION
## Summary
- Resolve #75: prevent multiline cell edits from being lost when saving via Ctrl/Cmd+S while a cell is still in edit mode
- Scope decision: in-scope (friendly)

## Changes
- Delay webview `save` message until after blur commits the current edit message
- Add regression coverage in webview shortcut tests for Ctrl/Cmd+S ordering

## Validation
- [x] npm run compile
- [x] npm test

## Risk Notes
- Touches only edit-mode save keyboard handling in webview script
- Save now runs on next macrotask after blur; this is intentional to preserve commit ordering

## Human Review Request
- Requested reviewer: @jonaraphael
- Please review behavior in: multiline editing + save flow
- Specific decision needed: confirm this resolves the reported repro steps on your environment

Fixes #75
